### PR TITLE
feat(collaboration): emulate codex plan/orchestrator behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ All notable changes to this project will be documented in this file.
 - Removed experimental `collab` runtime mode and related template wiring from mainline plugin behavior.
 - Simplified installer surface to a single idempotent `install` flow.
 - Updated docs, schema, and workflow configuration for current supported modes (`native`, `codex`).
+- Added experimental Codex collaboration profile gates (`runtime.collaborationProfile`, `runtime.orchestratorSubagents`) for plan/orchestrator parity.
+- Collaboration features now auto-enable by default in `runtime.mode="codex"` and can be explicitly enabled/disabled in any mode.
+- Added `runtime.collaborationToolProfile` (`opencode` | `codex`) to choose OpenCode tool translation guidance vs codex-style tool semantics in injected collaboration instructions.
+- Added managed `orchestrator` agent template sync under `~/.config/opencode/agents`, with visibility auto-gated by runtime mode.
 
 ## 0.2.3 - 2026-02-11
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -94,6 +94,18 @@ The plugin loads config in this order:
   - Adds explicit `before-header-transform` and `after-header-transform` request snapshots for message fetches.
 - `runtime.pidOffset: boolean`
   - Enables session-aware offset behavior for account selection.
+- `runtime.collaborationProfile: boolean`
+  - Experimental: enables Codex-style collaboration mode mapping from agent names (`plan` -> plan mode, `orchestrator` -> code mode profile).
+  - If omitted, defaults to `true` in `runtime.mode="codex"` and `false` otherwise.
+  - Explicit `true`/`false` works in any mode.
+- `runtime.orchestratorSubagents: boolean`
+  - Experimental: enables Codex-style subagent header hints for helper agents under collaboration profile mode.
+  - If omitted, inherits `runtime.collaborationProfile` effective value.
+  - Explicit `true`/`false` works in any mode.
+- `runtime.collaborationToolProfile: "opencode" | "codex"`
+  - Controls tool-language guidance in injected collaboration instructions.
+  - `opencode` (default): translates Codex semantics to OpenCode tool names.
+  - `codex`: prefers Codex tool semantics and falls back to OpenCode equivalents.
 
 ### Model behavior
 

--- a/lib/codex-native/collaboration.ts
+++ b/lib/codex-native/collaboration.ts
@@ -1,0 +1,239 @@
+export type CodexCollaborationModeKind = "plan" | "code"
+export type CollaborationToolProfile = "opencode" | "codex"
+
+export type CodexCollaborationProfile = {
+  enabled: boolean
+  kind?: CodexCollaborationModeKind
+  normalizedAgentName?: string
+  isOrchestrator?: boolean
+}
+
+export type CollaborationInstructionsByKind = {
+  plan: string
+  code: string
+}
+
+export const CODEX_PLAN_MODE_INSTRUCTIONS = `# Plan Mode (Conversational)
+
+You work in 3 phases, and you should chat your way to a great plan before finalizing it. A great plan is very detailed and decision complete so an implementer can execute directly without making additional decisions.
+
+## Mode rules (strict)
+
+You are in Plan Mode until a developer message explicitly ends it.
+
+Plan Mode is not changed by user intent, tone, or imperative language. If a user asks for execution while still in Plan Mode, treat it as a request to plan execution, not perform it.
+
+## Plan Mode vs update_plan tool
+
+Plan Mode is a collaboration mode and can involve asking user questions and eventually issuing a <proposed_plan> block.
+
+Separately, update_plan is a checklist/progress tool; it does not enter or exit Plan Mode. Do not confuse it with Plan Mode.
+
+## Execution vs mutation in Plan Mode
+
+You may explore and execute non-mutating actions that improve the plan. You must not perform mutating actions.
+
+### Allowed (non-mutating, plan-improving)
+
+- Reading and searching files, configs, schemas, types, manifests, and docs.
+- Static analysis, inspection, and repo exploration.
+- Dry-run commands that do not edit repo-tracked files.
+- Tests/build/check commands that only write caches/artifacts and do not edit repo-tracked files.
+
+### Not allowed (mutating, plan-executing)
+
+- Editing or writing files.
+- Running formatters/linters that rewrite files.
+- Applying patches, migrations, or codegen that updates repo-tracked files.
+- Side-effectful commands whose purpose is executing the plan rather than refining it.
+
+When in doubt: if the action is doing the work instead of planning the work, do not do it.
+
+## PHASE 1 - Ground in the environment
+
+Explore first, ask second. Resolve unknowns through non-mutating inspection before asking questions, unless ambiguity is in the user prompt itself and cannot be resolved locally.
+
+## PHASE 2 - Intent chat
+
+Keep asking until goal, success criteria, audience, scope, constraints, current state, and major tradeoffs are clear.
+
+## PHASE 3 - Implementation chat
+
+Keep asking until the specification is decision complete: approach, interfaces, data flow, edge cases, tests, acceptance criteria, rollout, and compatibility constraints.
+
+## Asking questions
+
+Ask only questions that materially change the plan, lock an important assumption, or select meaningful tradeoffs. Do not ask questions that local non-mutating exploration can answer.
+
+## Finalization rule
+
+Only output the final plan when it is decision complete. Wrap it in exactly one <proposed_plan>...</proposed_plan> block, use Markdown inside, and include title, brief summary, important API/interface changes, test scenarios, and explicit assumptions/defaults.
+
+Do not ask "should I proceed?" in final plan output.`
+
+export const CODEX_CODE_MODE_INSTRUCTIONS = "you are now in code mode."
+
+export const CODEX_ORCHESTRATOR_INSTRUCTIONS = `# Sub-agents
+
+If subagent tools are unavailable, proceed solo and ignore subagent-specific guidance.
+
+When subagents are available, delegate independent work in parallel, coordinate them with wait/send_input-style flow, and synthesize results before finalizing.
+
+When subagents are active, your primary role is coordination and synthesis; avoid doing worker implementation in parallel with active workers unless needed for unblock/fallback.`
+
+const OPENCODE_TOOLING_TRANSLATION_INSTRUCTIONS = `# Tooling Compatibility (OpenCode)
+
+Translate Codex-style tool intent to OpenCode-native tools:
+
+- exec_command -> bash
+- read/search/list -> read, grep, glob
+- apply_patch/edit_file -> apply_patch
+- spawn_agent -> task (launch a subagent)
+- send_input -> task with existing task_id (continue the same subagent)
+- wait -> do not return final output until spawned task(s) complete; poll/resume via task tool as needed
+- close_agent -> stop reusing task_id (no dedicated close tool in OpenCode)
+
+Always use the available OpenCode tool names and schemas in this runtime.`
+
+const CODEX_STYLE_TOOLING_INSTRUCTIONS = `# Tooling Compatibility (Codex-style)
+
+Prefer Codex-style workflow semantics and naming when reasoning about steps. If an exact Codex tool is unavailable, fall back to the nearest OpenCode equivalent and continue.`
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+function asString(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined
+  const trimmed = value.trim()
+  return trimmed ? trimmed : undefined
+}
+
+export function resolveHookAgentName(agent: unknown): string | undefined {
+  const direct = asString(agent)
+  if (direct) return direct
+  if (!isRecord(agent)) return undefined
+  return asString(agent.name) ?? asString(agent.agent)
+}
+
+function normalizeAgentName(agentName: string): string {
+  return agentName.trim().toLowerCase().replace(/\s+/g, "-")
+}
+
+function tokenizeAgentName(normalizedAgentName: string): string[] {
+  return normalizedAgentName
+    .split(/[-./:_]+/)
+    .map((token) => token.trim())
+    .filter((token) => token.length > 0)
+}
+
+function isCodexFamily(tokens: string[]): boolean {
+  return tokens[0] === "codex"
+}
+
+function isPlanPrimary(tokens: string[]): boolean {
+  return tokens.length === 1 && tokens[0] === "plan"
+}
+
+function isOrchestratorPrimary(tokens: string[]): boolean {
+  return tokens.length === 1 && tokens[0] === "orchestrator"
+}
+
+export function resolveCollaborationProfile(agent: unknown): CodexCollaborationProfile {
+  const name = resolveHookAgentName(agent)
+  if (!name) return { enabled: false }
+
+  const normalizedAgentName = normalizeAgentName(name)
+  const tokens = tokenizeAgentName(normalizedAgentName)
+  if (tokens.length === 0) return { enabled: false, normalizedAgentName }
+
+  const codexFamily = isCodexFamily(tokens)
+  const hasPlanToken = tokens.includes("plan") || tokens.includes("planner")
+  const hasOrchestratorToken = tokens.includes("orchestrator")
+
+  if ((isPlanPrimary(tokens) || (codexFamily && hasPlanToken)) && !hasOrchestratorToken) {
+    return {
+      enabled: true,
+      normalizedAgentName,
+      kind: "plan",
+      isOrchestrator: false
+    }
+  }
+
+  if (isOrchestratorPrimary(tokens) || (codexFamily && hasOrchestratorToken)) {
+    return {
+      enabled: true,
+      normalizedAgentName,
+      kind: "code",
+      isOrchestrator: true
+    }
+  }
+
+  if (
+    codexFamily &&
+    tokens.some((token) =>
+      ["default", "code", "review", "compact", "compaction", "execute", "pair", "pairprogramming"].includes(
+        token
+      )
+    )
+  ) {
+    return {
+      enabled: true,
+      normalizedAgentName,
+      kind: "code",
+      isOrchestrator: false
+    }
+  }
+
+  return { enabled: false, normalizedAgentName }
+}
+
+export function resolveCollaborationInstructions(
+  kind: CodexCollaborationModeKind,
+  instructions: CollaborationInstructionsByKind
+): string {
+  if (kind === "plan") return instructions.plan
+  return instructions.code
+}
+
+export function resolveToolingInstructions(profile: CollaborationToolProfile): string {
+  return profile === "codex" ? CODEX_STYLE_TOOLING_INSTRUCTIONS : OPENCODE_TOOLING_TRANSLATION_INSTRUCTIONS
+}
+
+export function mergeInstructions(base: string | undefined, extra: string): string {
+  const normalizedExtra = extra.trim()
+  if (!normalizedExtra) return base?.trim() ?? ""
+  const normalizedBase = base?.trim()
+  if (!normalizedBase) return normalizedExtra
+  if (normalizedBase.includes(normalizedExtra)) return normalizedBase
+  return `${normalizedBase}\n\n${normalizedExtra}`
+}
+
+export function resolveSubagentHeaderValue(agent: unknown): string | undefined {
+  const profile = resolveCollaborationProfile(agent)
+  const normalized = profile.normalizedAgentName
+  if (!profile.enabled || !normalized) {
+    return undefined
+  }
+
+  const tokens = tokenizeAgentName(normalized)
+  const isPrimary =
+    isPlanPrimary(tokens) ||
+    isOrchestratorPrimary(tokens) ||
+    (tokens[0] === "codex" &&
+      (tokens.includes("orchestrator") ||
+        tokens.includes("default") ||
+        tokens.includes("code") ||
+        tokens.includes("plan") ||
+        tokens.includes("planner") ||
+        tokens.includes("execute") ||
+        tokens.includes("pair") ||
+        tokens.includes("pairprogramming")))
+
+  if (isPrimary) return undefined
+  if (tokens.includes("review")) return "review"
+  if (tokens.includes("compact") || tokens.includes("compaction") || normalized === "compaction") {
+    return "compact"
+  }
+  return "collab_spawn"
+}

--- a/lib/orchestrator-agent.ts
+++ b/lib/orchestrator-agent.ts
@@ -1,0 +1,191 @@
+import fs from "node:fs/promises"
+import os from "node:os"
+import path from "node:path"
+
+export const CODEX_ORCHESTRATOR_AGENT_FILE = "orchestrator.md"
+export const CODEX_ORCHESTRATOR_AGENT_FILE_DISABLED = `${CODEX_ORCHESTRATOR_AGENT_FILE}.disabled`
+
+const CODEX_ORCHESTRATOR_AGENT_TEMPLATE = `---
+description: Codex-style orchestration profile for parallel delegation and synthesis.
+mode: primary
+---
+
+You are the Orchestrator agent.
+
+Coordinate multi-step tasks by delegating independent work to subagents, then synthesize results into one coherent outcome.
+
+# Sub-agents
+
+If subagent tools are unavailable, continue solo and ignore subagent-specific guidance.
+
+When subagents are available:
+- Decompose into independent subtasks.
+- Launch subagents in parallel when safe.
+- Use wait/send-input style coordination to drive progress.
+- Integrate findings and deliver a final answer.
+
+Do not create unnecessary delegation for trivial tasks.
+`
+
+export type InstallOrchestratorAgentInput = {
+  agentsDir?: string
+  force?: boolean
+}
+
+export type InstallOrchestratorAgentResult = {
+  agentsDir: string
+  filePath: string
+  created: boolean
+  updated: boolean
+}
+
+export type ReconcileOrchestratorAgentVisibilityInput = {
+  agentsDir?: string
+  visible: boolean
+  force?: boolean
+}
+
+export type ReconcileOrchestratorAgentVisibilityResult = {
+  agentsDir: string
+  filePath: string
+  visible: boolean
+  created: boolean
+  updated: boolean
+  moved: boolean
+}
+
+export function defaultOpencodeAgentsDir(env: Record<string, string | undefined> = process.env): string {
+  const xdgRoot = env.XDG_CONFIG_HOME?.trim()
+  if (xdgRoot) {
+    return path.join(xdgRoot, "opencode", "agents")
+  }
+  return path.join(os.homedir(), ".config", "opencode", "agents")
+}
+
+async function readIfExists(filePath: string): Promise<string | undefined> {
+  try {
+    return await fs.readFile(filePath, "utf8")
+  } catch {
+    return undefined
+  }
+}
+
+async function exists(filePath: string): Promise<boolean> {
+  return (await readIfExists(filePath)) !== undefined
+}
+
+async function ensureTemplateFile(filePath: string, force: boolean): Promise<{ created: boolean; updated: boolean }> {
+  const existingContent = await readIfExists(filePath)
+  if (existingContent === CODEX_ORCHESTRATOR_AGENT_TEMPLATE) {
+    return { created: false, updated: false }
+  }
+  if (existingContent !== undefined && !force) {
+    return { created: false, updated: false }
+  }
+
+  await fs.mkdir(path.dirname(filePath), { recursive: true })
+  await fs.writeFile(filePath, CODEX_ORCHESTRATOR_AGENT_TEMPLATE, { encoding: "utf8", mode: 0o600 })
+
+  return {
+    created: existingContent === undefined,
+    updated: existingContent !== undefined
+  }
+}
+
+export async function installOrchestratorAgent(
+  input: InstallOrchestratorAgentInput = {}
+): Promise<InstallOrchestratorAgentResult> {
+  const agentsDir = input.agentsDir ?? defaultOpencodeAgentsDir()
+  const filePath = path.join(agentsDir, CODEX_ORCHESTRATOR_AGENT_FILE)
+  const ensured = await ensureTemplateFile(filePath, input.force === true)
+
+  return {
+    agentsDir,
+    filePath,
+    created: ensured.created,
+    updated: ensured.updated
+  }
+}
+
+export async function reconcileOrchestratorAgentVisibility(
+  input: ReconcileOrchestratorAgentVisibilityInput
+): Promise<ReconcileOrchestratorAgentVisibilityResult> {
+  const agentsDir = input.agentsDir ?? defaultOpencodeAgentsDir()
+  const enabledPath = path.join(agentsDir, CODEX_ORCHESTRATOR_AGENT_FILE)
+  const disabledPath = path.join(agentsDir, CODEX_ORCHESTRATOR_AGENT_FILE_DISABLED)
+  const force = input.force === true
+  const enabledExists = await exists(enabledPath)
+  const disabledExists = await exists(disabledPath)
+
+  if (input.visible) {
+    if (enabledExists) {
+      const ensured = await ensureTemplateFile(enabledPath, force)
+      return {
+        agentsDir,
+        filePath: enabledPath,
+        visible: true,
+        created: ensured.created,
+        updated: ensured.updated,
+        moved: false
+      }
+    }
+
+    if (disabledExists) {
+      await fs.mkdir(path.dirname(enabledPath), { recursive: true })
+      await fs.rename(disabledPath, enabledPath)
+      return {
+        agentsDir,
+        filePath: enabledPath,
+        visible: true,
+        created: false,
+        updated: false,
+        moved: true
+      }
+    }
+
+    const ensured = await ensureTemplateFile(enabledPath, force)
+    return {
+      agentsDir,
+      filePath: enabledPath,
+      visible: true,
+      created: ensured.created,
+      updated: ensured.updated,
+      moved: false
+    }
+  }
+
+  if (disabledExists) {
+    const ensured = await ensureTemplateFile(disabledPath, force)
+    return {
+      agentsDir,
+      filePath: disabledPath,
+      visible: false,
+      created: ensured.created,
+      updated: ensured.updated,
+      moved: false
+    }
+  }
+
+  if (enabledExists) {
+    await fs.mkdir(path.dirname(disabledPath), { recursive: true })
+    await fs.rename(enabledPath, disabledPath)
+    return {
+      agentsDir,
+      filePath: disabledPath,
+      visible: false,
+      created: false,
+      updated: false,
+      moved: true
+    }
+  }
+
+  const ensured = await ensureTemplateFile(disabledPath, force)
+  return {
+    agentsDir,
+    filePath: disabledPath,
+    visible: false,
+    created: ensured.created,
+    updated: ensured.updated,
+    moved: false
+  }
+}

--- a/schemas/codex-config.schema.json
+++ b/schemas/codex-config.schema.json
@@ -61,6 +61,16 @@
         },
         "pidOffset": {
           "type": "boolean"
+        },
+        "collaborationProfile": {
+          "type": "boolean"
+        },
+        "orchestratorSubagents": {
+          "type": "boolean"
+        },
+        "collaborationToolProfile": {
+          "type": "string",
+          "enum": ["opencode", "codex"]
         }
       }
     },

--- a/test/codex-native-chat-hooks.test.ts
+++ b/test/codex-native-chat-hooks.test.ts
@@ -44,7 +44,10 @@ describe("codex-native chat hooks instruction source order", () => {
           }
         }
       ],
-      spoofMode: "codex"
+      spoofMode: "codex",
+      collaborationProfileEnabled: false,
+      orchestratorSubagentsEnabled: false,
+      collaborationToolProfile: "opencode"
     })
 
     expect(output.options.instructions).toBe("Cached template instructions")

--- a/test/codex-native-collaboration.test.ts
+++ b/test/codex-native-collaboration.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  mergeInstructions,
+  resolveCollaborationInstructions,
+  resolveCollaborationProfile,
+  resolveSubagentHeaderValue,
+  resolveToolingInstructions
+} from "../lib/codex-native/collaboration"
+
+describe("codex collaboration profile", () => {
+  it("maps plan agent to plan mode", () => {
+    const profile = resolveCollaborationProfile("plan")
+    expect(profile.enabled).toBe(true)
+    expect(profile.kind).toBe("plan")
+  })
+
+  it("maps orchestrator agent to code mode", () => {
+    const profile = resolveCollaborationProfile("Orchestrator")
+    expect(profile.enabled).toBe(true)
+    expect(profile.kind).toBe("code")
+  })
+
+  it("does not enable profile for unrelated build agent", () => {
+    const profile = resolveCollaborationProfile("build")
+    expect(profile.enabled).toBe(false)
+  })
+
+  it("maps codex review helper to review subagent header", () => {
+    expect(resolveSubagentHeaderValue("Codex Review")).toBe("review")
+  })
+
+  it("does not emit subagent header for plan/orchestrator primaries", () => {
+    expect(resolveSubagentHeaderValue("plan")).toBeUndefined()
+    expect(resolveSubagentHeaderValue("orchestrator")).toBeUndefined()
+  })
+
+  it("selects mode instructions by collaboration kind", () => {
+    const instructions = {
+      plan: "PLAN",
+      code: "CODE"
+    }
+    expect(resolveCollaborationInstructions("plan", instructions)).toBe("PLAN")
+    expect(resolveCollaborationInstructions("code", instructions)).toBe("CODE")
+  })
+
+  it("merges instructions once without duplicating", () => {
+    const merged = mergeInstructions("base", "extra")
+    expect(merged).toBe("base\n\nextra")
+    expect(mergeInstructions(merged, "extra")).toBe("base\n\nextra")
+  })
+
+  it("resolves tooling profiles", () => {
+    expect(resolveToolingInstructions("opencode")).toContain("Tooling Compatibility (OpenCode)")
+    expect(resolveToolingInstructions("codex")).toContain("Tooling Compatibility (Codex-style)")
+  })
+})

--- a/test/codex-native-in-vivo-instructions.test.ts
+++ b/test/codex-native-in-vivo-instructions.test.ts
@@ -32,4 +32,37 @@ describe("codex-native in-vivo instruction injection", () => {
     expect(result.outboundInstructions).toBe("Base Vivo Persona Voice")
     expect(result.outboundInstructions).not.toBe("OpenCode Host Instructions")
   })
+
+  it("injects codex-to-opencode tool call replacements for orchestrator prompts", async () => {
+    const result = await runCodexInVivoInstructionProbe({
+      hostInstructions: "OpenCode Host Instructions",
+      personalityKey: "vivo_persona",
+      personalityText: "Vivo Persona Voice",
+      agent: "orchestrator",
+      collaborationProfileEnabled: true,
+      orchestratorSubagentsEnabled: true,
+      collaborationToolProfile: "opencode"
+    })
+
+    expect(result.outboundInstructions).toContain("# Sub-agents")
+    expect(result.outboundInstructions).toContain("spawn_agent -> task")
+    expect(result.outboundInstructions).toContain("send_input -> task with existing task_id")
+    expect(result.outboundInstructions).toContain("wait -> do not return final output")
+    expect(result.outboundInstructions).toContain("close_agent -> stop reusing task_id")
+  })
+
+  it("injects plan mode semantics plus tool replacements for plan agent", async () => {
+    const result = await runCodexInVivoInstructionProbe({
+      hostInstructions: "OpenCode Host Instructions",
+      personalityKey: "vivo_persona",
+      personalityText: "Vivo Persona Voice",
+      agent: "plan",
+      collaborationProfileEnabled: true,
+      collaborationToolProfile: "opencode"
+    })
+
+    expect(result.outboundInstructions).toContain("# Plan Mode (Conversational)")
+    expect(result.outboundInstructions).toContain("must not perform mutating actions")
+    expect(result.outboundInstructions).toContain("spawn_agent -> task")
+  })
 })

--- a/test/helpers/codex-in-vivo.ts
+++ b/test/helpers/codex-in-vivo.ts
@@ -11,6 +11,10 @@ type InVivoProbeInput = {
   personalityKey: string
   personalityText: string
   modelSlug?: string
+  agent?: string
+  collaborationProfileEnabled?: boolean
+  orchestratorSubagentsEnabled?: boolean
+  collaborationToolProfile?: "opencode" | "codex"
   stripModelOptionsBeforeParams?: boolean
   modelInstructionsFallback?: string
   omitModelIdentityBeforeParams?: boolean
@@ -159,7 +163,10 @@ export async function runCodexInVivoInstructionProbe(input: InVivoProbeInput): P
   try {
     const hooks = await CodexAuthPlugin({} as never, {
       spoofMode: "codex",
-      behaviorSettings: { global: { personality: input.personalityKey } }
+      behaviorSettings: { global: { personality: input.personalityKey } },
+      collaborationProfileEnabled: input.collaborationProfileEnabled,
+      orchestratorSubagentsEnabled: input.orchestratorSubagentsEnabled,
+      collaborationToolProfile: input.collaborationToolProfile
     })
 
     const provider = {
@@ -193,7 +200,7 @@ export async function runCodexInVivoInstructionProbe(input: InVivoProbeInput): P
     await hooks["chat.params"]?.(
       {
         sessionID: "ses_vivo_1",
-        agent: "default",
+        agent: input.agent ?? "default",
         provider: {},
         message: {},
         model: {

--- a/test/orchestrator-agent.test.ts
+++ b/test/orchestrator-agent.test.ts
@@ -1,0 +1,67 @@
+import fs from "node:fs/promises"
+import os from "node:os"
+import path from "node:path"
+
+import { describe, expect, it } from "vitest"
+
+import {
+  CODEX_ORCHESTRATOR_AGENT_FILE,
+  CODEX_ORCHESTRATOR_AGENT_FILE_DISABLED,
+  installOrchestratorAgent,
+  reconcileOrchestratorAgentVisibility
+} from "../lib/orchestrator-agent"
+
+describe("orchestrator agent installer", () => {
+  it("writes orchestrator agent template and preserves existing content by default", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "opencode-codex-auth-orchestrator-agent-"))
+    const agentsDir = path.join(root, "agents")
+
+    const first = await installOrchestratorAgent({ agentsDir })
+    expect(first.created).toBe(true)
+    const filePath = path.join(agentsDir, CODEX_ORCHESTRATOR_AGENT_FILE)
+    const firstContent = await fs.readFile(filePath, "utf8")
+    expect(firstContent).toContain("mode: primary")
+    expect(firstContent).toContain("# Sub-agents")
+
+    await fs.writeFile(filePath, "custom orchestrator", "utf8")
+    const second = await installOrchestratorAgent({ agentsDir })
+    expect(second.created).toBe(false)
+    expect(second.updated).toBe(false)
+    expect(await fs.readFile(filePath, "utf8")).toBe("custom orchestrator")
+  })
+
+  it("updates existing orchestrator agent when forced", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "opencode-codex-auth-orchestrator-agent-force-"))
+    const agentsDir = path.join(root, "agents")
+    const filePath = path.join(agentsDir, CODEX_ORCHESTRATOR_AGENT_FILE)
+    await fs.mkdir(agentsDir, { recursive: true })
+    await fs.writeFile(filePath, "stale orchestrator", "utf8")
+
+    const result = await installOrchestratorAgent({ agentsDir, force: true })
+    expect(result.created).toBe(false)
+    expect(result.updated).toBe(true)
+
+    const content = await fs.readFile(filePath, "utf8")
+    expect(content).toContain("mode: primary")
+    expect(content).toContain("# Sub-agents")
+  })
+
+  it("toggles visibility by renaming enabled/disabled file variants", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "opencode-codex-auth-orchestrator-agent-toggle-"))
+    const agentsDir = path.join(root, "agents")
+
+    const hidden = await reconcileOrchestratorAgentVisibility({ agentsDir, visible: false })
+    expect(hidden.visible).toBe(false)
+    expect(hidden.filePath).toBe(path.join(agentsDir, CODEX_ORCHESTRATOR_AGENT_FILE_DISABLED))
+
+    const hiddenContent = await fs.readFile(hidden.filePath, "utf8")
+    expect(hiddenContent).toContain("mode: primary")
+
+    const visible = await reconcileOrchestratorAgentVisibility({ agentsDir, visible: true })
+    expect(visible.visible).toBe(true)
+    expect(visible.filePath).toBe(path.join(agentsDir, CODEX_ORCHESTRATOR_AGENT_FILE))
+
+    await expect(fs.access(path.join(agentsDir, CODEX_ORCHESTRATOR_AGENT_FILE_DISABLED))).rejects.toBeTruthy()
+    expect(await fs.readFile(visible.filePath, "utf8")).toContain("# Sub-agents")
+  })
+})


### PR DESCRIPTION
## Summary
- add codex-style collaboration profile emulation for `plan` and `orchestrator` agents, including mode-aware instruction injection and collaboration headers
- add runtime collaboration gates (`collaborationProfile`, `orchestratorSubagents`, `collaborationToolProfile`) with codex-mode defaults and env/config wiring
- manage an `orchestrator` agent file under `~/.config/opencode/agents` and gate visibility by effective collaboration mode, with installer + test coverage

## Verification
- npm run typecheck
- npm test
- npm run build