### PR TITLE
Fix use `rundll32.exe` for OAuth browser launch on Windows

### DIFF
--- a/lib/codex-native/browser.ts
+++ b/lib/codex-native/browser.ts
@@ -44,7 +44,8 @@ export function browserOpenInvocationFor(
     return { command: "open", args: [url] }
   }
   if (platform === "win32") {
-    return { command: "explorer.exe", args: [url] }
+    // Avoid cmd/explorer argument parsing edge-cases for OAuth URLs containing '&'.
+    return { command: "rundll32.exe", args: ["url.dll,FileProtocolHandler", url] }
   }
   return { command: "xdg-open", args: [url] }
 }

--- a/test/codex-native-browser-open.test.ts
+++ b/test/codex-native-browser-open.test.ts
@@ -11,10 +11,10 @@ describe("codex native browser launch", () => {
     })
   })
 
-  it("builds Windows start invocation", () => {
+  it("builds Windows browser invocation without shell parsing", () => {
     expect(browserOpenInvocationFor("https://example.com", "win32")).toEqual({
-      command: "explorer.exe",
-      args: ["https://example.com"]
+      command: "rundll32.exe",
+      args: ["url.dll,FileProtocolHandler", "https://example.com"]
     })
   })
 
@@ -23,8 +23,8 @@ describe("codex native browser launch", () => {
       "https://auth.openai.com/oauth/authorize?client_id=test-client&redirect_uri=http%3A%2F%2Flocalhost%3A1455%2Fcallback&state=test-state"
 
     expect(browserOpenInvocationFor(oauthUrl, "win32")).toEqual({
-      command: "explorer.exe",
-      args: [oauthUrl]
+      command: "rundll32.exe",
+      args: ["url.dll,FileProtocolHandler", oauthUrl]
     })
   })
 


### PR DESCRIPTION
## Summary
This PR fixes Windows OAuth auto-open failures by replacing `explorer.exe <url>` with `rundll32.exe url.dll,FileProtocolHandler <url>` for browser launch.

Issue #11 reports that `explorer.exe` can fail for OAuth authorize URLs that include query parameters (for example `&state=...`), which prevents browser auto-open and can lead to stale-session state mismatch on manual retries.

## Changes
- Updated Windows browser-open invocation in `browserOpenInvocationFor(...)`:
  - from: `explorer.exe <url>`
  - to: `rundll32.exe url.dll,FileProtocolHandler <url>`
- Kept the existing URL validation/allowlist behavior intact.
- Updated and clarified tests to assert Windows command + argument shape for both:
  - a normal HTTPS URL
  - an OAuth authorize URL with query parameters and ampersands

## Validation
- `npx vitest run test/codex-native-browser-open.test.ts`
- Result: 1 test file passed, 8 tests passed.