### PR TITLE
Prepare 1.10.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
-## 1.9.1 - 2026-07-18
+## 1.10.0 - 2026-07-18
 
 - Added `runtime.ultraReasoningEffort` to override Ultra's default `max` inference effort with `low`, `medium`, `high`, or `xhigh`.
 - Aligned Ultra's multi-agent mode prompt and inherited child policy with official Codex Multi-Agent V2 behavior.


### PR DESCRIPTION
## Summary
- retarget the prepared changelog from patch 1.9.1 to minor 1.10.0

## Validation
- npm run verify
- review gate