### PR TITLE
Fix unsupported max_output_tokens requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+- Fixed ChatGPT OAuth requests failing with `Unsupported parameter: max_output_tokens` by removing that field for every model before dispatch.
+
 ## 1.10.0 - 2026-07-18
 
 - Added `runtime.ultraReasoningEffort` to override Ultra's default `max` inference effort with `low`, `medium`, `high`, or `xhigh`.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -243,11 +243,11 @@ Custom model notes:
 ### GPT-5.4 long context
 
 - The plugin preserves an explicit request-body `service_tier` if your host already sets one.
-- The plugin preserves request-level `model_context_window`, `model_auto_compact_token_limit`, and `max_output_tokens` fields through all payload rewrites.
+- The plugin preserves request-level `model_context_window` and `model_auto_compact_token_limit` fields through payload rewrites.
 - For `gpt-5.4*`, the plugin clamps those request-level overrides to the currently documented GPT-5.4 long-context limits before sending the request:
   - `model_context_window <= 1,050,000`
   - `model_auto_compact_token_limit <= min(922,000, model_context_window - 128,000)`
-  - `max_output_tokens <= 128,000`
+- The ChatGPT backend rejects `max_output_tokens`, so the plugin removes that request field for every model before dispatch.
 - The `922,000` auto-compact ceiling is the full-window practical safe-input cap derived from the published `1,050,000` total context budget minus the published `128,000` max output budget.
 - If you request a smaller `model_context_window`, the plugin also preserves the same output headroom by clamping `model_auto_compact_token_limit` to `model_context_window - 128,000`.
 - The live Codex catalog currently still reports `context_window: 272000` for `gpt-5.4`, so any larger `model_context_window` value is an explicit request override rather than a catalog default.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -121,7 +121,8 @@ Notes:
 
 - The live Codex catalog still advertises a standard `272000` context window for `gpt-5.4`.
 - Larger `model_context_window` values are explicit request overrides.
-- The plugin clamps `model_context_window` to `1,050,000`, `model_auto_compact_token_limit` to `min(922,000, model_context_window - 128,000)`, and `max_output_tokens` to `128,000` when they are set on `gpt-5.4*` requests.
+- The plugin clamps `model_context_window` to `1,050,000` and `model_auto_compact_token_limit` to `min(922,000, model_context_window - 128,000)` when they are set on `gpt-5.4*` requests.
+- The ChatGPT backend rejects `max_output_tokens`, so the plugin removes that request field for every model before dispatch.
 - The `922,000` ceiling is the full-window practical safe-input budget derived from the documented `1,050,000` total context window minus the documented `128,000` max output budget.
 - If you request a smaller `model_context_window`, the plugin preserves the same output headroom by clamping `model_auto_compact_token_limit` to `model_context_window - 128,000`.
 - OpenAI's current GPT-5.4 guidance says prompts above the standard `272,000` input window are billed at higher long-context rates.

--- a/lib/codex-native/request-transform-payload.ts
+++ b/lib/codex-native/request-transform-payload.ts
@@ -55,15 +55,19 @@ function applyGpt54LongContextClampsToPayloadWithContext(input: {
   selectedModelSlug?: string
   customModels?: Record<string, CustomModelConfig>
 }): boolean {
+  let changed = false
+  if ("max_output_tokens" in input.payload) {
+    delete input.payload.max_output_tokens
+    changed = true
+  }
+
   const modelCandidates = resolvePayloadModelCandidatesForClamps({
     payload: input.payload,
     selectedModelSlug: input.selectedModelSlug,
     customModels: input.customModels
   })
   const isGpt54 = modelCandidates.some((candidate) => candidate.trim().toLowerCase().startsWith("gpt-5.4"))
-  if (!isGpt54) return false
-
-  let changed = false
+  if (!isGpt54) return changed
 
   const contextWindow = asFiniteNumber(input.payload.model_context_window)
   if (contextWindow !== undefined && contextWindow > GPT_5_4_MAX_CONTEXT_WINDOW) {
@@ -82,12 +86,6 @@ function applyGpt54LongContextClampsToPayloadWithContext(input: {
   const autoCompact = asFiniteNumber(input.payload.model_auto_compact_token_limit)
   if (autoCompact !== undefined && autoCompact > autoCompactMax) {
     input.payload.model_auto_compact_token_limit = autoCompactMax
-    changed = true
-  }
-
-  const maxOutputTokens = asFiniteNumber(input.payload.max_output_tokens)
-  if (maxOutputTokens !== undefined && maxOutputTokens > GPT_5_4_MAX_OUTPUT_TOKENS) {
-    input.payload.max_output_tokens = GPT_5_4_MAX_OUTPUT_TOKENS
     changed = true
   }
 

--- a/test/request-transform-gpt54-long-context.test.ts
+++ b/test/request-transform-gpt54-long-context.test.ts
@@ -12,6 +12,33 @@ const PRIORITY_BEHAVIOR_SETTINGS: BehaviorSettings = {
   }
 }
 
+describe("ChatGPT backend request compatibility", () => {
+  it("strips max_output_tokens from non-GPT-5.4 requests", async () => {
+    const request = new Request("https://chatgpt.com/backend-api/codex/responses", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        model: "gpt-5.5",
+        max_output_tokens: 128_000,
+        input: [{ type: "message", role: "user", content: [{ type: "input_text", text: "hello" }] }]
+      })
+    })
+
+    const transformed = await transformOutboundRequestPayload({
+      request,
+      stripReasoningReplayEnabled: false,
+      remapDeveloperMessagesToUserEnabled: false,
+      compatInputSanitizerEnabled: false,
+      promptCacheKeyOverrideEnabled: false
+    })
+
+    const body = JSON.parse(await transformed.request.text()) as { max_output_tokens?: number }
+
+    expect(transformed.changed).toBe(true)
+    expect(body.max_output_tokens).toBeUndefined()
+  })
+})
+
 describe("GPT-5.4 long-context request clamps", () => {
   it("preserves valid 1M-context fields without mutating service_tier on the main payload path", async () => {
     const request = new Request("https://chatgpt.com/backend-api/codex/responses", {
@@ -83,7 +110,7 @@ describe("GPT-5.4 long-context request clamps", () => {
     expect(body.service_tier).toBeUndefined()
     expect(body.model_context_window).toBe(1_050_000)
     expect(body.model_auto_compact_token_limit).toBe(922_000)
-    expect(body.max_output_tokens).toBe(128_000)
+    expect(body.max_output_tokens).toBeUndefined()
   })
 
   it("reserves output headroom when a smaller GPT-5.4 context window is requested", async () => {
@@ -117,7 +144,7 @@ describe("GPT-5.4 long-context request clamps", () => {
     expect(transformed.changed).toBe(true)
     expect(body.model_context_window).toBe(300_000)
     expect(body.model_auto_compact_token_limit).toBe(172_000)
-    expect(body.max_output_tokens).toBe(128_000)
+    expect(body.max_output_tokens).toBeUndefined()
   })
 
   it("applies GPT-5.4 clamps to custom aliases that target GPT-5.4", async () => {
@@ -157,7 +184,7 @@ describe("GPT-5.4 long-context request clamps", () => {
     expect(transformed.changed).toBe(true)
     expect(body.model_context_window).toBe(1_050_000)
     expect(body.model_auto_compact_token_limit).toBe(922_000)
-    expect(body.max_output_tokens).toBe(128_000)
+    expect(body.max_output_tokens).toBeUndefined()
   })
 
   it("keeps wrapper transforms scoped instead of silently applying GPT-5.4 clamps", async () => {


### PR DESCRIPTION
## Summary

- remove `max_output_tokens` from every ChatGPT backend request
- keep GPT-5.4 context-window and auto-compaction clamps model-specific
- add regression coverage for GPT-5.5 and update the long-context documentation

## Verification

- `npm run verify`

Closes #49