### PR TITLE
Fix quota window classification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+- Fixed quota snapshots assigning weekly usage and reset times to the `5h` row when the backend returns windows in a different order or omits the 5-hour window.
+
 ## 1.10.0 - 2026-07-18
 
 - Added `runtime.ultraReasoningEffort` to override Ultra's default `max` inference effort with `low`, `medium`, `high`, or `xhigh`.

--- a/lib/codex-quota-fetch.ts
+++ b/lib/codex-quota-fetch.ts
@@ -27,6 +27,18 @@ function normalizePct(value: number): number | undefined {
   return Math.round(value)
 }
 
+function windowNameFromDuration(fallbackName: string, windowData: Record<string, unknown>): string {
+  const windowSeconds = asNumber(windowData.limit_window_seconds)
+  if (windowSeconds === undefined) return fallbackName
+
+  const matches = (expectedSeconds: number) =>
+    windowSeconds >= expectedSeconds * 0.95 && windowSeconds <= expectedSeconds * 1.05
+
+  if (matches(5 * 60 * 60)) return "5h"
+  if (matches(7 * 24 * 60 * 60)) return "weekly"
+  return fallbackName
+}
+
 function parseWindowLimit(name: string, windowData: unknown): CodexLimit | null {
   if (!isRecord(windowData)) return null
   const usedPct = asNumber(windowData.used_percent)
@@ -35,7 +47,7 @@ function parseWindowLimit(name: string, windowData: unknown): CodexLimit | null 
   if (leftPct === undefined) return null
   const resetsAt = toEpochMs(asNumber(windowData.reset_at ?? windowData.resets_at))
   return {
-    name,
+    name: windowNameFromDuration(name, windowData),
     leftPct,
     ...(resetsAt ? { resetsAt } : null)
   }
@@ -93,7 +105,8 @@ function snapshotFromUsagePayload(input: {
   if (limits.length === 0 && Array.isArray(input.payload.limits)) {
     for (const entry of input.payload.limits) {
       if (!isRecord(entry)) continue
-      const name = typeof entry.name === "string" ? entry.name.toLowerCase() : "requests"
+      const fallbackName = typeof entry.name === "string" ? entry.name.toLowerCase() : "requests"
+      const name = windowNameFromDuration(fallbackName, entry)
       const leftPctDirect = asNumber(entry.leftPct ?? entry.left_pct)
       const usedPct = asNumber(entry.used_percent)
       const remaining = asNumber(entry.remaining)

--- a/lib/codex-status-ui.ts
+++ b/lib/codex-status-ui.ts
@@ -1,4 +1,5 @@
-import type { CodexRateLimitSnapshot, AccountRecord, CodexLimit } from "./types.js"
+import type { CodexRateLimitSnapshot, AccountRecord } from "./types.js"
+import { resolveQuotaWindows } from "./quota-windows.js"
 import { ANSI } from "./ui/tty.js"
 
 const FULL_BLOCK = "█"
@@ -40,26 +41,6 @@ function formatResetTimestamp(resetsAt: number | undefined, now = Date.now()): s
   }
   const months = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"]
   return `resets ${timeStr} ${date.getDate()} ${months[date.getMonth()]}`
-}
-
-function findLimitByName(snap: CodexRateLimitSnapshot, names: string[]): (typeof snap.limits)[number] | undefined {
-  const lowered = names.map((name) => name.toLowerCase())
-  return snap.limits.find((limit) => lowered.includes(limit.name.toLowerCase()))
-}
-
-function resolveQuotaRows(snap: CodexRateLimitSnapshot | undefined): {
-  fiveHour?: CodexLimit
-  weekly?: CodexLimit
-} {
-  if (!snap) {
-    return { fiveHour: undefined, weekly: undefined }
-  }
-  const fiveHour = findLimitByName(snap, ["5h", "primary", "requests"]) ?? snap.limits[0]
-  const weekly =
-    findLimitByName(snap, ["weekly", "secondary", "tokens"]) ??
-    snap.limits.find((limit) => limit !== fiveHour) ??
-    snap.limits[1]
-  return { fiveHour, weekly }
 }
 
 function formatAccountLabel(input: {
@@ -179,7 +160,7 @@ export function renderDashboard(
 
     const expired = typeof acc.expires === "number" && Number.isFinite(acc.expires) && acc.expires <= Date.now()
 
-    const rows = resolveQuotaRows(snap)
+    const rows = resolveQuotaWindows(snap)
     lines.push(
       renderQuotaLine({
         prefix: style === "menu" ? `${colorize("│", ANSI.cyan, useColor)}  ├─ ` : "├─ ",

--- a/lib/quota-threshold-alerts.ts
+++ b/lib/quota-threshold-alerts.ts
@@ -1,4 +1,5 @@
-import type { CodexLimit, CodexRateLimitSnapshot } from "./types.js"
+import type { CodexRateLimitSnapshot } from "./types.js"
+import { resolveQuotaWindows } from "./quota-windows.js"
 
 export const QUOTA_WARNING_THRESHOLDS_PCT = [25, 20, 10, 5, 2.5, 0] as const
 
@@ -43,22 +44,6 @@ function formatPct(value: number): string {
 
 function sanitizeReasonPct(value: number): string {
   return formatPct(value).replace(".", "_")
-}
-
-function findLimitByName(snapshot: CodexRateLimitSnapshot, names: string[]): CodexLimit | undefined {
-  const lowered = names.map((name) => name.toLowerCase())
-  return snapshot.limits.find((limit) => lowered.includes(limit.name.toLowerCase()))
-}
-
-function resolveQuotaWindows(snapshot: CodexRateLimitSnapshot): {
-  fiveHour?: CodexLimit
-  weekly?: CodexLimit
-} {
-  const fiveHour = findLimitByName(snapshot, ["5h", "primary", "requests"]) ?? snapshot.limits[0]
-  const weekly =
-    findLimitByName(snapshot, ["weekly", "secondary", "tokens"]) ??
-    snapshot.limits.find((limit) => limit !== fiveHour && limit.name.toLowerCase() !== fiveHour?.name.toLowerCase())
-  return { fiveHour, weekly }
 }
 
 function findHighestReachedThresholdIndex(leftPct: number): number {

--- a/lib/quota-windows.ts
+++ b/lib/quota-windows.ts
@@ -1,0 +1,25 @@
+import type { CodexLimit, CodexRateLimitSnapshot } from "./types.js"
+
+function findLimitByName(snapshot: CodexRateLimitSnapshot, names: string[]): CodexLimit | undefined {
+  const lowered = new Set(names.map((name) => name.toLowerCase()))
+  return snapshot.limits.find((limit) => lowered.has(limit.name.toLowerCase()))
+}
+
+export function resolveQuotaWindows(snapshot: CodexRateLimitSnapshot | undefined): {
+  fiveHour?: CodexLimit
+  weekly?: CodexLimit
+} {
+  if (!snapshot) return {}
+
+  const semanticWeekly = findLimitByName(snapshot, ["weekly"])
+  const semanticFiveHour = findLimitByName(snapshot, ["5h"])
+  const legacyWeekly = findLimitByName(snapshot, ["secondary", "tokens"])
+  const legacyFiveHour = findLimitByName(snapshot, ["primary", "requests"])
+  const weekly = semanticWeekly ?? legacyWeekly
+  const fiveHour = semanticFiveHour ?? legacyFiveHour ?? snapshot.limits.find((limit) => limit !== weekly)
+
+  return {
+    fiveHour,
+    weekly: weekly ?? snapshot.limits.find((limit) => limit !== fiveHour)
+  }
+}

--- a/test/codex-quota-fetch.test.ts
+++ b/test/codex-quota-fetch.test.ts
@@ -8,7 +8,7 @@ describe("codex quota fetch", () => {
     resetStubbedGlobals()
   })
 
-  it("parses wham usage response into requests/tokens limits", async () => {
+  it("classifies wham usage windows by duration", async () => {
     const fetchMock = vi.fn<(url: string | URL | Request, init?: RequestInit) => Promise<Response>>(
       async (_url: string | URL | Request, _init?: RequestInit) =>
         new Response(
@@ -47,8 +47,8 @@ describe("codex quota fetch", () => {
     expect(fetchMock).toHaveBeenCalledTimes(1)
     expect(fetchMock.mock.calls[0]?.[0]).toBe("https://chatgpt.com/backend-api/wham/usage")
     expect(snapshot?.limits).toEqual([
-      { name: "requests", leftPct: 75, resetsAt: 1_710_000_000_000 },
-      { name: "tokens", leftPct: 30, resetsAt: 1_711_000_000_000 }
+      { name: "5h", leftPct: 75, resetsAt: 1_710_000_000_000 },
+      { name: "weekly", leftPct: 30, resetsAt: 1_711_000_000_000 }
     ])
     expect(snapshot?.credits).toEqual({
       hasCredits: true,
@@ -86,7 +86,33 @@ describe("codex quota fetch", () => {
 
     expect(fetchMock).toHaveBeenCalledTimes(1)
     expect(fetchMock.mock.calls[0]?.[0]).toBe("https://api.openai.com/api/codex/usage")
-    expect(snapshot?.limits).toEqual([{ name: "requests", leftPct: 90, resetsAt: 1_712_000_000_000 }])
+    expect(snapshot?.limits).toEqual([{ name: "5h", leftPct: 90, resetsAt: 1_712_000_000_000 }])
+  })
+
+  it("classifies a weekly primary window by duration instead of position", async () => {
+    const fetchMock = vi.fn<(url: string | URL | Request, init?: RequestInit) => Promise<Response>>(
+      async () =>
+        new Response(
+          JSON.stringify({
+            rate_limit: {
+              primary_window: {
+                used_percent: 34,
+                limit_window_seconds: 604800,
+                reset_at: 1_711_000_000
+              }
+            }
+          }),
+          { status: 200 }
+        )
+    )
+
+    const snapshot = await fetchQuotaSnapshotFromBackend({
+      accessToken: "ey.a.jwt",
+      now: 222,
+      fetchImpl: fetchMock
+    })
+
+    expect(snapshot?.limits).toEqual([{ name: "weekly", leftPct: 66, resetsAt: 1_711_000_000_000 }])
   })
 
   it("routes quota requests with ChatGPT-Account-Id header for account isolation parity", async () => {

--- a/test/codex-status-ui.test.ts
+++ b/test/codex-status-ui.test.ts
@@ -68,4 +68,28 @@ describe("codex status ui", () => {
     expect(text).toContain("Unknown, account expired")
     expect(text).toContain("Credits")
   })
+
+  it("does not display a weekly-only snapshot as the 5h quota", () => {
+    const now = Date.now()
+    const out = renderDashboard(
+      {
+        accounts: [{ identityKey: "acc|u@e.com|plus", email: "u@e.com", plan: "plus", enabled: true }],
+        snapshots: {
+          "acc|u@e.com|plus": {
+            updatedAt: now,
+            modelFamily: "gpt-5.3-codex",
+            limits: [{ name: "weekly", leftPct: 66, resetsAt: now + 7 * 24 * 60 * 60 * 1000 }]
+          }
+        }
+      },
+      { useColor: false }
+    )
+
+    const fiveHourLine = out.find((line) => line.includes("5h"))
+    const weeklyLine = out.find((line) => line.includes("Weekly"))
+    expect(fiveHourLine).toContain("0% left")
+    expect(fiveHourLine).toContain("Unknown, no snapshot yet")
+    expect(weeklyLine).toContain("66% left")
+    expect(weeklyLine).toContain("resets")
+  })
 })

--- a/test/quota-threshold-alerts.test.ts
+++ b/test/quota-threshold-alerts.test.ts
@@ -85,4 +85,23 @@ describe("quota threshold alerts", () => {
       }
     ])
   })
+
+  it("does not treat a semantic weekly-only limit as the 5h window", () => {
+    const evaluated = evaluateQuotaThresholds({
+      snapshot: {
+        updatedAt: Date.now(),
+        modelFamily: "gpt-5.3-codex",
+        limits: [{ name: "weekly", leftPct: 0, resetsAt: 1_711_000_000_000 }]
+      },
+      previousState: DEFAULT_QUOTA_THRESHOLD_TRACKER_STATE
+    })
+
+    expect(evaluated.exhaustedCrossings).toEqual([
+      {
+        window: "weekly",
+        resetsAt: 1_711_000_000_000,
+        reasonCode: "quota_limit_exhausted_weekly"
+      }
+    ])
+  })
 })


### PR DESCRIPTION
## Summary

- classify 5-hour and weekly quota windows from the backend-provided duration instead of their array position
- share quota-window selection between status rendering and automatic threshold/cooldown handling
- preserve positional fallback behavior for older stored snapshots without duration-derived names

## Verification

- `npm run verify`
- 889 tests passed, 1 skipped

Fixes #48