### PR TITLE
feat: prepare GPT-6 Astra support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+- Prepared catalog-driven GPT-6 Astra support with Codex `0.153.2` fallback identity, GPT-6 provider-family metadata, Fast/1M/Pro aliases, and Pro request serialization.
+- Corrected official GPT-5.6 and GPT-6 Astra 1M aliases to use the published 1,050,000-token context, 922,000-token input, and 128,000-token output limits independently of Codex's internal override cap.
+
 ## 1.10.0 - 2026-07-18
 
 - Added `runtime.ultraReasoningEffort` to override Ultra's default `max` inference effort with `low`, `medium`, `high`, or `xhigh`.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -150,8 +150,10 @@ Mode-derived runtime defaults when omitted:
 - A successful live `/backend-api/codex/models` response wins for every matching slug. Official GitHub entries supply only slugs missing from that response.
 - The plugin does not combine fields across matching live and GitHub entries. GitHub-supplied models retain `catalog_source: "github_fallback"` so their provenance remains observable.
 - When live catalog data is unavailable, the normalized GitHub snapshot supplies the fallback catalog.
-- Do not rely on a static model list: GPT-5.6-era models and variants can arrive from either source under those precedence rules.
+- Do not rely on a static model list: GPT-5.6 and GPT-6-era models and variants can arrive from either source under those precedence rules.
 - Catalog visibility is not an entitlement guarantee. Actual backend access still depends on the authenticated account and may require re-authentication after an account or model rollout.
+
+GPT-6 Astra is admitted only when the live account catalog or the version-matched official Codex catalog contains `gpt-6-astra`; the plugin does not create the canonical model from documentation alone. The offline Codex client fallback is `0.153.2`, whose official snapshot contains Astra; the model itself declares `0.153.0` as its minimum client version.
 
 - `global.personality: string`
   - Personality key applied to all models unless overridden.
@@ -166,7 +168,7 @@ Mode-derived runtime defaults when omitted:
   - There is no public concurrency setting; OpenCode remains responsible for agent execution and lifecycle.
   - The overlay is generated from pinned Codex source with exact, count-checked substitutions backed by pinned OpenCode task-tool evidence. See `docs/development/PROMPT_COMPATIBILITY.md`.
 - `global.reasoningMode: "standard" | "pro"` (optional)
-  - GPT-5.6 reasoning mode, emitted as `reasoning.mode` independently of `reasoning.effort`.
+  - GPT-5.6 and GPT-6 Astra reasoning mode, emitted as `reasoning.mode` independently of `reasoning.effort`.
   - An explicit request value is preserved. The same per-model and per-variant precedence applies.
 - `global.reasoningSummary: "auto" | "concise" | "detailed" | "none"`
   - Global reasoning summary format override forwarded upstream as `reasoning.summary`.
@@ -233,9 +235,9 @@ Custom model notes:
 ### Generated Fast, 1M, and Pro models
 
 - `modelAliases.fast` defaults to `true`. Any catalog model advertising priority/Fast gets a separate `[Model Name] Fast` provider model routed to the canonical slug with `service_tier: "priority"`.
-- `modelAliases.extendedContext` defaults to `true`. Models advertising a larger `max_context_window` get `[Model Name] 1M`. GPT-5.6 Sol/Terra/Luna use the official 1,050,000 context, 922,000 max input, and 128,000 max output contract even while a Codex catalog reports a smaller normal window.
+- `modelAliases.extendedContext` defaults to `true`. Models advertising a larger `max_context_window` get `[Model Name] 1M`. GPT-5.6 Sol/Terra/Luna and GPT-6 Astra use the official 1,050,000 context, 922,000 max input, and 128,000 max output contract even while a Codex catalog reports a smaller normal window or override cap.
 - `modelAliases.pro` defaults to `false` for ChatGPT OAuth and `true` for API-key auth. Explicit `true` or `false` overrides the auth-aware default.
-- `[Model Name] Pro` is the same canonical GPT-5.6 Sol/Terra/Luna slug with `reasoning: { mode: "pro" }`; effort remains independently selectable.
+- `[Model Name] Pro` is the same canonical GPT-5.6 Sol/Terra/Luna or GPT-6 Astra slug with `reasoning: { mode: "pro" }`; effort remains independently selectable.
 - Fast, 1M, and Pro are three separate aliases. The plugin does not create combination aliases.
 - API-key handling is limited to cloning/routing provider entries; OAuth storage, rotation, refresh, and API-key authentication remain unchanged.
 - Account-scoped catalog responses remain authoritative. The plugin does not copy metadata across canonical slugs.

--- a/docs/development/CONFIG_FIELDS.md
+++ b/docs/development/CONFIG_FIELDS.md
@@ -39,7 +39,7 @@ Top-level:
   - When omitted, the selected model's live catalog `default_reasoning_level` is used, typically `"medium"`.
   - User config can still override reasoning effort globally, per model, or per variant.
 - `global.reasoningMode: "standard" | "pro"`
-  - Independent GPT-5.6 reasoning mode; request-level values win.
+  - Independent GPT-5.6 and GPT-6 Astra reasoning mode; request-level values win.
 - `modelAliases.fast: boolean` (default `true`)
 - `modelAliases.extendedContext: boolean` (default `true`)
 - `modelAliases.pro: boolean` (default API `true`, OAuth `false`)

--- a/docs/development/UPSTREAM_SYNC.md
+++ b/docs/development/UPSTREAM_SYNC.md
@@ -10,12 +10,14 @@ Track the OpenCode and Codex releases this plugin is aligned to, and how to keep
 - Upstream HEAD inspected: GitHub latest release/tag via `npm run check:upstream`
 - Native Codex reference file: `packages/opencode/src/plugin/openai/codex.ts`
 - Codex upstream repo: `https://github.com/openai/codex`
-- Codex upstream release track: `rust-v0.144.1` for the GPT-5.6 Ultra contract
+- Codex upstream release track: `rust-v0.153.2` for GPT-6 Astra readiness; `rust-v0.144.1` remains the pinned GPT-5.6 Ultra prompt source
 - Local dependency target:
   - `@opencode-ai/plugin`: `^1.17.18`
   - `@opencode-ai/sdk`: `^1.17.18`
 
 ## Latest parity audit (2026-07-10)
+
+GPT-6 Astra readiness was checked separately on 2026-09-04 against `rust-v0.153.2`. The plugin now uses the model's upstream minimum client version (`0.153.0`) as its offline fallback, consumes Astra only through the existing live/official catalog path, maps it to the GPT-6 provider family, and enables the documented Fast, 1M, and Pro surfaces when their existing configuration gates allow them.
 
 - Verified OAuth constants and authorize URL semantics against upstream `codex.ts`.
 - Verified native callback URI now uses `http://localhost:1455/auth/callback`.

--- a/docs/development/UPSTREAM_SYNC.md
+++ b/docs/development/UPSTREAM_SYNC.md
@@ -17,7 +17,7 @@ Track the OpenCode and Codex releases this plugin is aligned to, and how to keep
 
 ## Latest parity audit (2026-07-10)
 
-GPT-6 Astra readiness was checked separately on 2026-09-04 against `rust-v0.153.2`. The plugin now uses the model's upstream minimum client version (`0.153.0`) as its offline fallback, consumes Astra only through the existing live/official catalog path, maps it to the GPT-6 provider family, and enables the documented Fast, 1M, and Pro surfaces when their existing configuration gates allow them.
+GPT-6 Astra readiness was checked separately on 2026-09-04 against `rust-v0.153.2`. The plugin now uses `0.153.2` as its offline fallback, consumes Astra only through the existing live/official catalog path, maps it to the GPT-6 provider family, and enables the documented Fast, 1M, and Pro surfaces when their existing configuration gates allow them.
 
 - Verified OAuth constants and authorize URL semantics against upstream `codex.ts`.
 - Verified native callback URI now uses `http://localhost:1455/auth/callback`.

--- a/docs/examples/codex-config.jsonc
+++ b/docs/examples/codex-config.jsonc
@@ -56,7 +56,7 @@
     // Optional reasoning effort override forwarded upstream.
     // Omit to use the selected model's live catalog default_reasoning_level (typically "medium").
     // "reasoningEffort": "high",
-    // GPT-5.6 mode is independent of effort.
+    // GPT-5.6 and GPT-6 Astra mode is independent of effort.
     // "reasoningMode": "standard",
 
     // Reasoning summary format forwarded upstream as reasoning.summary.

--- a/lib/codex-native/client-identity.ts
+++ b/lib/codex-native/client-identity.ts
@@ -13,7 +13,7 @@ import type { CodexOriginator } from "./originator.js"
 import { URL } from "node:url"
 
 const DEFAULT_PLUGIN_VERSION = "0.1.0"
-const DEFAULT_CODEX_CLIENT_VERSION = "0.144.0"
+const DEFAULT_CODEX_CLIENT_VERSION = "0.153.2"
 const CODEX_CLIENT_VERSION_CACHE_FILE = path.join(defaultOpencodeCachePath(), "codex-client-version.json")
 const CODEX_CLIENT_VERSION_TTL_MS = 60 * 60 * 1000
 const CODEX_GITHUB_RELEASES_API = "https://api.github.com/repos/openai/codex/releases/latest"

--- a/lib/codex-native/request-transform-model.ts
+++ b/lib/codex-native/request-transform-model.ts
@@ -198,7 +198,10 @@ export function getModelLookupCandidates(model: { id?: string; api?: { id?: stri
 }
 
 export function supportsReasoningMode(modelCandidates: string[]): boolean {
-  return modelCandidates.some((candidate) => candidate.trim().toLowerCase().startsWith("gpt-5.6"))
+  return modelCandidates.some((candidate) => {
+    const normalized = candidate.trim().toLowerCase()
+    return normalized.startsWith("gpt-5.6") || normalized.startsWith("gpt-6-astra")
+  })
 }
 
 export function getSelectedModelLookupCandidates(model: { id?: string }): string[] {

--- a/lib/model-catalog/provider.ts
+++ b/lib/model-catalog/provider.ts
@@ -335,7 +335,7 @@ function applyGeneratedAliases(input: {
       // generated ourselves; never replace an independently supplied collision.
       if (catalogBySlug.has(aliasSlug) || (existingAlias && !isGeneratedAlias)) {
         input.allowed?.add(aliasSlug)
-        return
+        return false
       }
       const alias = cloneValue(base)
       alias.id = aliasSlug
@@ -353,6 +353,7 @@ function applyGeneratedAliases(input: {
       options.codexCustomModelConfig = { slug: aliasSlug, targetModel: slug, ...behavior }
       input.providerModels[aliasSlug] = alias
       input.allowed?.add(aliasSlug)
+      return true
     }
     const providerServiceTiers = Array.isArray(base.service_tiers) ? base.service_tiers : []
     const providerSpeedTiers = Array.isArray(base.additional_speed_tiers) ? base.additional_speed_tiers : []
@@ -374,10 +375,11 @@ function applyGeneratedAliases(input: {
       maxContext &&
       (officialMillionTokenContext || !normalContext || maxContext > normalContext)
     ) {
-      add("1m", {}, `${display} 1M`)
-      const alias = input.providerModels[`${slug}-1m`]
-      if (alias)
+      const created = add("1m", {}, `${display} 1M`)
+      const alias = created ? input.providerModels[`${slug}-1m`] : undefined
+      if (alias) {
         alias.limit = { ...(asRecord(alias.limit) ?? {}), context: maxContext, input: 922_000, output: 128_000 }
+      }
     }
     if (input.settings.pro && (officialGpt56 || officialGpt6Astra)) {
       add("pro", { reasoningMode: "pro" }, `${display} Pro`)

--- a/lib/model-catalog/provider.ts
+++ b/lib/model-catalog/provider.ts
@@ -117,7 +117,8 @@ function resolveProviderTransport(
 
 function resolveFamily(slug: string): string {
   if (slug.includes("codex")) return "gpt-codex"
-  if (slug.startsWith("gpt-")) return "gpt-5"
+  const gptFamily = slug.match(/^gpt-(\d+)/i)
+  if (gptFamily?.[1]) return `gpt-${gptFamily[1]}`
   if (slug.startsWith("o")) return "o-series"
   return "openai"
 }
@@ -364,19 +365,23 @@ function applyGeneratedAliases(input: {
     if (input.settings.fast && priority && fast) add("fast", { serviceTier: "priority" }, `${display} Fast`)
 
     const officialGpt56 = /^gpt-5\.6(?:-(sol|terra|luna))?$/i.test(slug)
-    const maxContext = catalog?.max_context_window ?? (officialGpt56 ? 1_050_000 : undefined)
+    const officialGpt6Astra = /^gpt-6-astra$/i.test(slug)
+    const officialMillionTokenContext = officialGpt56 || officialGpt6Astra
+    const maxContext = officialMillionTokenContext ? 1_050_000 : catalog?.max_context_window
     const normalContext = catalog?.context_window ?? asFiniteNumber(asRecord(base.limit)?.context)
     if (
       input.settings.extendedContext &&
       maxContext &&
-      (officialGpt56 || !normalContext || maxContext > normalContext)
+      (officialMillionTokenContext || !normalContext || maxContext > normalContext)
     ) {
       add("1m", {}, `${display} 1M`)
       const alias = input.providerModels[`${slug}-1m`]
       if (alias)
         alias.limit = { ...(asRecord(alias.limit) ?? {}), context: maxContext, input: 922_000, output: 128_000 }
     }
-    if (input.settings.pro && officialGpt56) add("pro", { reasoningMode: "pro" }, `${display} Pro`)
+    if (input.settings.pro && (officialGpt56 || officialGpt6Astra)) {
+      add("pro", { reasoningMode: "pro" }, `${display} Pro`)
+    }
   }
 }
 

--- a/lib/model-catalog/shared.ts
+++ b/lib/model-catalog/shared.ts
@@ -143,7 +143,7 @@ export type ApplyCodexCatalogInput = {
 
 export const CODEX_MODELS_ENDPOINT = "https://chatgpt.com/backend-api/codex/models"
 export const CODEX_GITHUB_MODELS_URL_PREFIX = "https://raw.githubusercontent.com/openai/codex"
-export const DEFAULT_CLIENT_VERSION = "0.144.0"
+export const DEFAULT_CLIENT_VERSION = "0.153.2"
 export const CACHE_TTL_MS = 15 * 60 * 1000
 export const FETCH_TIMEOUT_MS = 5000
 export const EFFORT_SUFFIX_REGEX = /-(none|minimal|low|medium|high|xhigh|max|ultra)$/i

--- a/schemas/codex-config.schema.json
+++ b/schemas/codex-config.schema.json
@@ -151,7 +151,7 @@
         "reasoningMode": {
           "type": "string",
           "enum": ["standard", "pro"],
-          "description": "GPT-5.6 reasoning mode, independent of reasoningEffort."
+          "description": "GPT-5.6 and GPT-6 Astra reasoning mode, independent of reasoningEffort."
         },
         "reasoningSummary": {
           "$ref": "#/$defs/reasoningSummary"

--- a/test/codex-native-client-version.test.ts
+++ b/test/codex-native-client-version.test.ts
@@ -19,10 +19,10 @@ describe("codex client version resolution", () => {
     expect(__testOnly.resolveCodexClientVersion(cacheFile)).toBe("0.98.0")
   })
 
-  it("falls back to 0.144.0 when cache file is missing", async () => {
+  it("falls back to 0.153.2 when cache file is missing", async () => {
     const dir = await makeTmpDir()
     const cacheFile = path.join(dir, "missing.json")
-    expect(__testOnly.resolveCodexClientVersion(cacheFile)).toBe("0.144.0")
+    expect(__testOnly.resolveCodexClientVersion(cacheFile)).toBe("0.153.2")
   })
 
   it("refreshes stale cache from GitHub release tag", async () => {

--- a/test/codex-native-request-transform.test.ts
+++ b/test/codex-native-request-transform.test.ts
@@ -265,7 +265,7 @@ describe("codex reasoning replay stripping", () => {
   })
 })
 
-describe("GPT-5.6 reasoning mode", () => {
+describe("Pro reasoning mode", () => {
   it("serializes Pro aliases as nested reasoning.mode and preserves explicit mode", async () => {
     const makeRequest = (reasoning: Record<string, unknown>) =>
       new Request("https://chatgpt.com/backend-api/codex/responses", {
@@ -305,6 +305,24 @@ describe("GPT-5.6 reasoning mode", () => {
     })
 
     expect(JSON.parse(await transformed.request.text()).reasoning).toEqual({ effort: "high" })
+  })
+
+  it("applies Pro mode to GPT-6 Astra", async () => {
+    const request = new Request("https://chatgpt.com/backend-api/codex/responses", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ model: "gpt-6-astra", reasoning: { effort: "max" } })
+    })
+    const transformed = await transformOutboundRequestPayload({
+      request,
+      selectedModelSlug: "gpt-6-astra-pro",
+      stripReasoningReplayEnabled: false,
+      remapDeveloperMessagesToUserEnabled: false,
+      compatInputSanitizerEnabled: false,
+      promptCacheKeyOverrideEnabled: false
+    })
+
+    expect(JSON.parse(await transformed.request.text()).reasoning).toEqual({ effort: "max", mode: "pro" })
   })
 })
 

--- a/test/model-catalog.fetch-cache.test.ts
+++ b/test/model-catalog.fetch-cache.test.ts
@@ -50,11 +50,11 @@ describe("model catalog fetch and primary cache", () => {
     const fetchImpl = vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
       const endpoint = typeof url === "string" ? url : url instanceof URL ? url.toString() : new URL(url.url).toString()
       if (endpoint.includes("/backend-api/codex/models")) {
-        expect(endpoint).toContain("client_version=0.144.0")
+        expect(endpoint).toContain("client_version=0.153.2")
         const headers = init?.headers as Record<string, string>
         expect(headers.authorization).toBe("Bearer at")
         expect(headers["chatgpt-account-id"]).toBe("acc_123")
-        expect(headers.version).toBe("0.144.0")
+        expect(headers.version).toBe("0.153.2")
 
         return new Response(
           JSON.stringify({
@@ -65,7 +65,7 @@ describe("model catalog fetch and primary cache", () => {
       }
 
       expect(endpoint).toBe(
-        "https://raw.githubusercontent.com/openai/codex/rust-v0.144.0/codex-rs/models-manager/models.json"
+        "https://raw.githubusercontent.com/openai/codex/rust-v0.153.2/codex-rs/models-manager/models.json"
       )
       return new Response(
         JSON.stringify({

--- a/test/model-catalog.provider-models.test.ts
+++ b/test/model-catalog.provider-models.test.ts
@@ -455,6 +455,26 @@ describe("model catalog provider model mapping", () => {
     expect(providerModels["gpt-5.6-luna-pro"]?.name).toBe("Independent Pro Model")
   })
 
+  it("preserves limits from an independently supplied Astra 1M entry", () => {
+    const providerModels: Record<string, Record<string, unknown>> = {
+      "gpt-6-astra": { id: "gpt-6-astra", name: "GPT-6 Astra" },
+      "gpt-6-astra-1m": {
+        id: "gpt-6-astra-1m",
+        name: "Upstream Astra 1M",
+        limit: { context: 900_000, input: 800_000, output: 100_000 }
+      }
+    }
+    applyGeneratedAliasesToProviderModels({
+      providerModels,
+      settings: { fast: false, extendedContext: true, pro: false }
+    })
+    expect(providerModels["gpt-6-astra-1m"]?.limit).toEqual({
+      context: 900_000,
+      input: 800_000,
+      output: 100_000
+    })
+  })
+
   it("preserves provider models when the catalog is temporarily unavailable", () => {
     const providerModels: Record<string, Record<string, unknown>> = {
       "gpt-5.3-codex": makeBaselineModel("gpt-5.3-codex")

--- a/test/model-catalog.provider-models.test.ts
+++ b/test/model-catalog.provider-models.test.ts
@@ -314,6 +314,64 @@ describe("model catalog provider model mapping", () => {
     })
   })
 
+  it("maps the catalog-backed GPT-6 Astra contract", () => {
+    const providerModels: Record<string, Record<string, unknown>> = {}
+    applyCodexCatalogToProviderModels({
+      providerModels,
+      catalogModels: [
+        {
+          slug: "gpt-6-astra",
+          display_name: "GPT-6-Astra",
+          context_window: 272000,
+          max_context_window: 872000,
+          input_modalities: ["text", "image"] as const,
+          service_tiers: [{ id: "priority", name: "Fast" }],
+          additional_speed_tiers: ["fast"],
+          default_reasoning_level: "low",
+          supported_reasoning_levels: [
+            { effort: "low" },
+            { effort: "medium" },
+            { effort: "high" },
+            { effort: "xhigh" },
+            { effort: "max" }
+          ]
+        }
+      ],
+      aliasSettings: { fast: true, extendedContext: true, pro: true }
+    })
+
+    expect(Object.keys(providerModels).sort()).toEqual([
+      "gpt-6-astra",
+      "gpt-6-astra-1m",
+      "gpt-6-astra-fast",
+      "gpt-6-astra-pro"
+    ])
+    expect(providerModels["gpt-6-astra"]).toMatchObject({
+      family: "gpt-6",
+      limit: { context: 272000, input: 272000, output: 128000 },
+      capabilities: { reasoning: true, attachment: true },
+      variants: {
+        low: { reasoningEffort: "low" },
+        medium: { reasoningEffort: "medium" },
+        high: { reasoningEffort: "high" },
+        xhigh: { reasoningEffort: "xhigh" },
+        max: { reasoningEffort: "max" }
+      }
+    })
+    expect(providerModels["gpt-6-astra-1m"]).toMatchObject({
+      api: { id: "gpt-6-astra" },
+      limit: { context: 1050000, input: 922000, output: 128000 }
+    })
+    expect(providerModels["gpt-6-astra-fast"]).toMatchObject({
+      api: { id: "gpt-6-astra" },
+      options: { codexCustomModelConfig: { targetModel: "gpt-6-astra", serviceTier: "priority" } }
+    })
+    expect(providerModels["gpt-6-astra-pro"]).toMatchObject({
+      api: { id: "gpt-6-astra" },
+      options: { codexCustomModelConfig: { targetModel: "gpt-6-astra", reasoningMode: "pro" } }
+    })
+  })
+
   it("shapes API-key provider metadata without taking over authentication", () => {
     const providerModels = {
       "gpt-5.6-sol": {


### PR DESCRIPTION
## Summary
- update the Codex fallback identity and catalog baseline to 0.153.2 so the official snapshot can supply GPT-6 Astra
- map Astra into the GPT-6 family and support catalog-gated Fast, 1M, and Pro aliases
- serialize Astra Pro mode and document and test the catalog contract

## Validation
- `npm run verify`
- smoke-tested the `rust-v0.153.2` `models.json` Astra row through the built catalog mapper
